### PR TITLE
Close the JavaScript for WET pre-CodeFest session and updates to the schedule

### DIFF
--- a/activites.html
+++ b/activites.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Activités &mdash; Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
+<title>Activités — Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="French description / Description en français" />

--- a/activities.html
+++ b/activities.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Activities &mdash; Web Experience Toolkit CodeFest 2013</title>
+<title>Activities — Web Experience Toolkit CodeFest 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />

--- a/ateliers-de-preparation.html
+++ b/ateliers-de-preparation.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Ateliers de préparation &mdash; Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
+<title>Ateliers de préparation — Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="French description / Description en français" />

--- a/breakout-sessions.html
+++ b/breakout-sessions.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Breakout sessions &mdash; Web Experience Toolkit CodeFest 2013</title>
+<title>Breakout sessions — Web Experience Toolkit CodeFest 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />

--- a/codesprints.html
+++ b/codesprints.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Codesprints &mdash; Web Experience Toolkit CodeFest 2013</title>
+<title>Codesprints — Web Experience Toolkit CodeFest 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />

--- a/emplacements.html
+++ b/emplacements.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Emplacements &mdash; Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
+<title>Emplacements — Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="French description / Description en français" />

--- a/horaire.html
+++ b/horaire.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Horaire &mdash; Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
+<title>Horaire — Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="French description / Description en français" />
@@ -76,7 +76,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 <h1 id="wb-cont">Horaire</h1>
 
 <section>
-	<h2>Jeudi 8&nbsp;août&nbsp;&mdash; Université d'Ottawa</h2>
+	<h2>Jeudi 8 août — Université d'Ottawa</h2>
 	<table>
 		<thead>
 			<tr>
@@ -87,52 +87,52 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 		</thead>
 		<tbody>
 			<tr>
-				<td>8&nbsp;h&nbsp;30&nbsp;&ndash; 9&nbsp;h&nbsp;00</td>
+				<td>8 h 30 ‒ 9 h 00</td>
 				<td>Ramassage des badges</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>9&nbsp;h&nbsp;00&nbsp;&ndash; 9&nbsp;h&nbsp;30</td>
+				<td>9 h 00 ‒ 9 h 30</td>
 				<td>Amorce et sujets d’ordre administratif</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>9&nbsp;h&nbsp;30&nbsp;&ndash; 10&nbsp;h&nbsp;00</td>
+				<td>9 h 30 ‒ 10 h 00</td>
 				<td>Mots de bienvenue</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>10&nbsp;h&nbsp;00&nbsp;&ndash; 11&nbsp;h&nbsp;00</td>
-				<td>Conférence n&ordm;&nbsp;1 &mdash; <a href="http://ben.balter.com/about/">Ben Balter</a>, <a href="https://github.com/benbalter" lang="en">Githubber</a></td>
+				<td>10 h 00 ‒ 11 h 00</td>
+				<td>Conférence nº 1 — <a href="http://ben.balter.com/about/">Ben Balter</a>, <a href="https://github.com/benbalter" lang="en">Githubber</a></td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>11&nbsp;h&nbsp;00&nbsp;&ndash; 12&nbsp;h&nbsp;00</td>
-				<td>Conférence n&ordm;&nbsp;2 &mdash; <a href="http://www.raymondcamden.com/page.cfm/about-me">Raymond Camden</a>, Développeur évangéliste chez Adobe</td></td>
+				<td>11 h 00 ‒ 12 h 00</td>
+				<td>Conférence nº 2 — <a href="http://www.raymondcamden.com/page.cfm/about-me">Raymond Camden</a>, Développeur évangéliste chez Adobe</td></td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>12&nbsp;h&nbsp;00&nbsp;&ndash; 13&nbsp;h&nbsp;00</td>
-				<td>Pause déjeuner&nbsp;: Apportez votre propre déjeuner ou allez au restaurant. Le déjeuner n'est pas inclu.</td>
+				<td>12 h 00 ‒ 13 h 00</td>
+				<td>Pause déjeuner : Apportez votre propre déjeuner ou allez au restaurant. Le déjeuner n'est pas inclu.</td>
 				<td>Là où vous voulez</td>
 			</tr>
 			<tr>
-				<td>13&nbsp;h&nbsp;00&nbsp;&ndash; 13&nbsp;h&nbsp;20</td>
+				<td>13 h 00 ‒ 13 h 20</td>
 				<td>Présentation des séances en ateliers et des <em lang="en">sprints</em> de codage</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>13&nbsp;h&nbsp;30&nbsp;&ndash; 16&nbsp;h&nbsp;00</td>
+				<td>13 h 30 ‒ 16 h 00</td>
 				<td>Séance en ateliers/courses et programmation ouverte</td>
 				<td>Pavillon Lamoureux (plusieurs pièces sont disponibles)</td>
 			</tr>
 			<tr>
-				<td>16&nbsp;h&nbsp;00&nbsp;&ndash; 16&nbsp;h&nbsp;30</td>
+				<td>16 h 00 ‒ 16 h 30</td>
 				<td>Atelier de préparation à la seconde journée</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>							
 			<tr>
-				<td>17&nbsp;h&nbsp;00&nbsp;&ndash; 19&nbsp;h&nbsp;00</td>
+				<td>17 h 00 ‒ 19 h 00</td>
 				<td>Échange entre réalisateurs du #w2p</td>
 				<td>The Exchange Pub (Centre Rideau)</td>							
 			</tr>
@@ -140,7 +140,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 	</table>
 </section>
 <section>
-	<h2>Vendredi 9&nbsp;août&nbsp;&mdash; Université d'Ottawa</h2>
+	<h2>Vendredi 9 août — Université d'Ottawa</h2>
 	<table>
 		<thead>
 			<tr>
@@ -151,43 +151,43 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 		</thead>
 		<tbody>
 			<tr>
-				<td>8&nbsp;h&nbsp;30&nbsp;&ndash; 9&nbsp;h&nbsp;00</td>
+				<td>8 h 30 ‒ 9 h 00</td>
 				<td>Ramasage des badges</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>						
-				<td>9&nbsp;h&nbsp;30&nbsp;&ndash; 10&nbsp;h&nbsp;00</td>
+				<td>9 h 30 ‒ 10 h 00</td>
 				<td>Compte rendu de la première journée</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>	
 			<tr>
-				<td>10&nbsp;h&nbsp;00&nbsp;&ndash; 11&nbsp;h&nbsp;00</td>
-				<td>Conférence n&ordm;&nbsp;3 &mdash; <a href="http://www.hilarylittle.com/">Hilary Little</a>, Gouvernment du Canada</td>
+				<td>10 h 00 ‒ 11 h 00</td>
+				<td>Conférence nº 3 — <a href="http://www.hilarylittle.com/">Hilary Little</a>, Gouvernment du Canada</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>11&nbsp;h&nbsp;00&nbsp;&ndash; 12&nbsp;h&nbsp;00</td>
-				<td>Conférence n&ordm;&nbsp;4 &mdash; À déterminer</td>
+				<td>11 h 00 ‒ 12 h 00</td>
+				<td>Conférence nº 4 — À déterminer</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>12&nbsp;h&nbsp;00&nbsp;&ndash; 13&nbsp;h&nbsp;00</td>
+				<td>12 h 00 ‒ 13 h 00</td>
 				<td>Pause déjeuner : Apportez votre propre déjeuner ou allez au restaurant. Le déjeuner n'est pas inclu.</td>
 				<td>Là où vous voulez</td>
 			</tr>
 			<tr>
-				<td>13&nbsp;h&nbsp;00&nbsp;&ndash; 15&nbsp;h&nbsp;30</td>
+				<td>13 h 00 ‒ 15 h 30</td>
 				<td><em lang="en">Design jam</em> et <em lang="en">sprints</em> de codage</td>
 				<td>Pavillon Lamoureux (plusieurs pièces disponibles)</td>
 			</tr>
 			<tr>
-				<td>15&nbsp;h&nbsp;30&nbsp;&ndash; 16&nbsp;h&nbsp;00</td>
+				<td>15 h 30 ‒ 16 h 00</td>
 				<td>Résumé du <em lang="en">Design jam</em></td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 			<tr>
-				<td>16&nbsp;h&nbsp;00&nbsp;&ndash; 17&nbsp;h&nbsp;00</td>
-				<td>Conférence n&ordm;&nbsp;5 &mdash; Thème principal</td>
+				<td>16 h 00 ‒ 17 h 00</td>
+				<td>Conférence nº 5 — Thème principal</td>
 				<td>Auditorium du pavillon Marion</td>
 			</tr>
 		</tbody>

--- a/index-fra.html
+++ b/index-fra.html
@@ -75,7 +75,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 <!-- MainContentStart -->
 <h1 id="wb-cont" class="wb-invisible">Journées de codage de la Boîte à outils de l’expérience Web édition 2013</h1>
 <p>La communauté de la Boîte à outils de l'expérience Web est fière de tenir une deuxième journée de codage, les 8 et 9 août à l'Université d'Ottawa. Nous invitons à se joindre à nous les codeurs Web, les designers, les professionels en accessibilité et en facilité d'emploi, les rédacteurs techniques et toutes autres personnes intéressées à contribuer au développement de la version 4 de la Boîte à outils de l'expérience Web.</p>
-<p>Les journées de codage édition 2013 comprendront des activités pour tous, y compris&nbsp;:</p>
+<p>Les journées de codage édition 2013 comprendront des activités pour tous, y compris :</p>
 <ul>
 	<li>Des discours-thème.</li>
 	<li>Des <em lang="en">sprints</em> de codage.</li>

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Language selection&nbsp;/ <span lang="fr">Sélection de la langue</span></h1>
+<h1 id="wb-cont">Language selection / <span lang="fr">Sélection de la langue</span></h1>
 
 <div class="span-4">
 <ul class="button-group">

--- a/locations.html
+++ b/locations.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Locations &mdash; Web Experience Toolkit CodeFest 2013</title>
+<title>Locations — Web Experience Toolkit CodeFest 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />

--- a/pre-CodeFest-sessions.html
+++ b/pre-CodeFest-sessions.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Pre-CodeFest sessions &mdash; Web Experience Toolkit CodeFest 2013</title>
+<title>Pre-CodeFest sessions — Web Experience Toolkit CodeFest 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />

--- a/schedule.html
+++ b/schedule.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Schedule &mdash; Web Experience Toolkit CodeFest 2013</title>
+<title>Schedule — Web Experience Toolkit CodeFest 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />
@@ -76,7 +76,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 <h1 id="wb-cont">Schedule</h1>
 
 <section>				
-	<h2>Thursday, August&nbsp;8&nbsp;&mdash; University of Ottawa</h2>
+	<h2>Thursday, August 8 — University of Ottawa</h2>
 	<table>
 		<thead>
 			<tr>
@@ -87,52 +87,52 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 		</thead>
 		<tbody>
 			<tr>
-				<td>8:30&nbsp;&ndash;&nbsp;9:00</td>
+				<td>8:30 ‒ 9:00</td>
 				<td>Name tag pick-up</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>9:00&nbsp;&ndash;&nbsp;9:30</td>
+				<td>9:00 ‒ 9:30</td>
 				<td>Ice breaker and house keeping</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>9:30&nbsp;&ndash;&nbsp;10:00</td>
+				<td>9:30 ‒ 10:00</td>
 				<td>Welcome addresses</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>10:00&nbsp;&ndash;&nbsp;11:00</td>
-				<td>Keynote 1 &mdash; <a href="http://ben.balter.com/about/">Ben Balter</a>, <a href="https://github.com/benbalter">Githubber</a></td>
+				<td>10:00 ‒ 11:00</td>
+				<td>Keynote 1 — <a href="http://ben.balter.com/about/">Ben Balter</a>, <a href="https://github.com/benbalter">Githubber</a></td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>11:00&nbsp;&ndash;&nbsp;12:00</td>
-				<td>Keynote 2 &mdash; <a href="http://www.raymondcamden.com/page.cfm/about-me">Raymond Camden</a>, Developer Evangelist for Adobe</td>
+				<td>11:00 ‒ 12:00</td>
+				<td>Keynote 2 — <a href="http://www.raymondcamden.com/page.cfm/about-me">Raymond Camden</a>, Developer Evangelist for Adobe</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>12:00&nbsp;&ndash;&nbsp;1:00</td>
+				<td>12:00 ‒ 1:00</td>
 				<td>Lunch break: Bring your own lunch or eat out. Lunch is not provided.</td>
 				<td>Where you want</td>
 			</tr>
 			<tr>
-				<td>1:00&nbsp;&ndash;&nbsp;1:20</td>
+				<td>1:00 ‒ 1:20</td>
 				<td>Presentation of breakout sessions and code sprints</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>1:30&nbsp;&ndash;&nbsp;4:00</td>
+				<td>1:30 ‒ 4:00</td>
 				<td>break out session/codesprint + open coding</td>
 				<td>Lamoureux Hall (various rooms)</td>
 			</tr>
 			<tr>	
-				<td>4:00&nbsp;&ndash;&nbsp;4:30</td>
+				<td>4:00 ‒ 4:30</td>
 				<td>Get Ready for Day Two session</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>5:00&nbsp;&ndash;&nbsp;7:00</td>
+				<td>5:00 ‒ 7:00</td>
 				<td>#w2p Implementers' Exchange</td>
 				<td>The Exchange Pub (Rideau Centre)</td>
 			</tr>
@@ -140,7 +140,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 	</table>
 </section>
 <section>
-	<h2>Friday, August&nbsp;9&nbsp;&mdash; University of Ottawa</h2>
+	<h2>Friday, August 9 — University of Ottawa</h2>
 	<table>
 		<thead>
 			<tr>
@@ -151,43 +151,43 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 		</thead>
 		<tbody>
 			<tr>
-				<td>8:30&nbsp;&ndash;&nbsp;9:00</td>
+				<td>8:30 ‒ 9:00</td>
 				<td>Name tag pick-up</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>9:30&nbsp;&ndash;&nbsp;10:00</td>
+				<td>9:30 ‒ 10:00</td>
 				<td>First day recap</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>10:00&nbsp;&ndash;&nbsp;11:00</td>
-				<td>Keynote 3 &mdash; <a href="http://www.hilarylittle.com/">Hilary Little</a>, Government of Canada</td>
+				<td>10:00 ‒ 11:00</td>
+				<td>Keynote 3 — <a href="http://www.hilarylittle.com/">Hilary Little</a>, Government of Canada</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>11:00&nbsp;&ndash;&nbsp;12:00</td>
-				<td>Keynote 4 &mdash; <abbr title="To be determined">TBD</a></td>
+				<td>11:00 ‒ 12:00</td>
+				<td>Keynote 4 — <abbr title="To be determined">TBD</a></td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>12:00&nbsp;&ndash;&nbsp;1:00</td>
+				<td>12:00 ‒ 1:00</td>
 				<td>Lunch break: Bring your own lunch or eat out. Lunch is not provided.</td>
 				<td>Where you want</td>
 			</tr>
 			<tr>
-				<td>1:00&nbsp;&ndash;&nbsp;3:30</td>
+				<td>1:00 ‒ 3:30</td>
 				<td>Design jam and Code sprints</td>
 				<td>Lamoureux Hall (various rooms)</td>
 			</tr>
 			<tr>
-				<td>3:30&nbsp;&ndash;&nbsp;4:00</td>
+				<td>3:30 ‒ 4:00</td>
 				<td>Design jam Redux</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 			<tr>
-				<td>4:00&nbsp;&ndash;&nbsp;5:00</td>
-				<td>Keynote 5 &mdash; Overarching theme</td>
+				<td>4:00 ‒ 5:00</td>
+				<td>Keynote 5 — Overarching theme</td>
 				<td>Marion Hall Auditorium</td>
 			</tr>
 		</tbody>

--- a/seances-en-ateliers.html
+++ b/seances-en-ateliers.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Séances en ateliers &mdash; Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
+<title>Séances en ateliers — Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="French description / Description en français" />
@@ -82,7 +82,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 
 <section>
 	<h2>Diriger une séance en ateliers</h2>
-	<p>Diriger une séance en ateliers lors des Journées de codage est simple&nbsp;:</p>
+	<p>Diriger une séance en ateliers lors des Journées de codage est simple :</p>
 	<ol>
 		<li>Préparez une présentation d'une seule diapositive au sujet de votre séance en atelier (<a href="https://marybethbaker.github.io/Codefest-One-Slide-Wonders/">exemple<span class="wb-invisible"> d'une présentation de séance en ateliers</span></a>).</li>
 		<li>Présentez votre séance en ateliers aux participants des Journées de codage.</li>

--- a/sprints-de-codage.html
+++ b/sprints-de-codage.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licence-fra.html -->
-<title>Sprints de codage &mdash; Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
+<title>Sprints de codage — Journées de codage de la Boîte à outils de l’expérience Web édition 2013</title>
 
 <link rel="shortcut icon" href="wet-boew/dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="French description / Description en français" />
@@ -82,7 +82,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 
 <section>
 	<h2>Diriger un <em lang="en">sprint</em> de codage</h2>
-	<p>Diriger un <em lang="en">sprint</em> de codage lors des Journées de codage est simple&nbsp;:</p>
+	<p>Diriger un <em lang="en">sprint</em> de codage lors des Journées de codage est simple :</p>
 	<ol>
 		<li>Donnez une présentation de 10‒15 minutes pour présenter les attentes du <em lang="en">sprint</em>.</li>
 		<li>Séparez les gens en groupes et divisez les tâches à accomplir. Si une tâche est complexe, prévoyez faire un essai à blanc avec une partie du travail pour vous assurer que tout le monde avance dans la bonne direction.</li>


### PR DESCRIPTION
No more JavaScript for WET sessions are planned; linked to the slide presentation.
